### PR TITLE
New command to validate any command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new matcher `toHaveReceivedAnyCommand`
+
 ## [4.0.1] - 2024-10-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new matcher `toHaveReceivedAnyCommand`
 
+### Changed
+
+- `aws-sdk-client-mock` is now a peer dependency. This should allow usage
+  with a broader range of `aws-sdk-client-mock` versions without feer to install
+  conflicting versions
+
 ## [4.0.1] - 2024-10-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ import {
   toHaveReceivedNthCommandWith,
   toReceiveLastCommandWith,
   toHaveReceivedLastCommandWith,
+  toReceiveAnyCommand,
+  toHaveReceivedAnyCommand,
 } from "aws-sdk-client-mock-vitest";
 
 expect.extend({
@@ -70,6 +72,8 @@ expect.extend({
   toHaveReceivedNthCommandWith,
   toReceiveLastCommandWith,
   toHaveReceivedLastCommandWith,
+  toReceiveAnyCommand,
+  toHaveReceivedAnyCommand,
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,20 +15,20 @@
         "tslib": "^2.8.0"
       },
       "devDependencies": {
-        "@aws-sdk/client-ec2": "^3.670.0",
-        "@aws-sdk/client-s3": "^3.670.0",
-        "@eslint/js": "^9.12.0",
-        "@stylistic/eslint-plugin": "^2.9.0",
+        "@aws-sdk/client-ec2": "^3.712.0",
+        "@aws-sdk/client-s3": "^3.712.0",
+        "@eslint/js": "^9.17.0",
+        "@stylistic/eslint-plugin": "^2.12.1",
         "@types/eslint__js": "^8.42.3",
-        "@types/node": "^22.7.5",
-        "@vitest/coverage-v8": "^2.1.3",
-        "@vitest/eslint-plugin": "^1.1.7",
-        "eslint": "^9.12.0",
+        "@types/node": "^22.10.2",
+        "@vitest/coverage-v8": "^2.1.8",
+        "@vitest/eslint-plugin": "^1.1.16",
+        "eslint": "^9.17.0",
         "eslint-config-flat-gitignore": "^0.3.0",
-        "eslint-plugin-perfectionist": "^3.9.0",
-        "typescript": "^5.6.3",
-        "typescript-eslint": "^8.9.0",
-        "vitest": "^2.1.3"
+        "eslint-plugin-perfectionist": "^4.3.0",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.18.0",
+        "vitest": "^2.1.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -264,54 +264,55 @@
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.670.0.tgz",
-      "integrity": "sha512-e19jbRUEJ/1HPxmS0V0mByyfzjdXak/pzuenkmiusYtKPTTfIPo+APfjNW6cwhj9LrVFgcIYxuIX2E2CYKFRtw==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.712.0.tgz",
+      "integrity": "sha512-c3QOwjF7GILMJ1G/gGurlU37ALh4mFEuqsvUnANe4WN4bX4GDVyq4ttm3DEJymlP9DuQpqztpNjldO7Xpg7igg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.670.0",
-        "@aws-sdk/client-sts": "3.670.0",
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/credential-provider-node": "3.670.0",
-        "@aws-sdk/middleware-host-header": "3.667.0",
-        "@aws-sdk/middleware-logger": "3.667.0",
-        "@aws-sdk/middleware-recursion-detection": "3.667.0",
-        "@aws-sdk/middleware-sdk-ec2": "3.667.0",
-        "@aws-sdk/middleware-user-agent": "3.669.0",
-        "@aws-sdk/region-config-resolver": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-endpoints": "3.667.0",
-        "@aws-sdk/util-user-agent-browser": "3.670.0",
-        "@aws-sdk/util-user-agent-node": "3.669.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/client-sts": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.1.6",
+        "@smithy/util-waiter": "^3.2.0",
+        "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -320,69 +321,69 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.670.0.tgz",
-      "integrity": "sha512-8Pwu1K+PgbYpXDaGKNy5hEbRH5FXHlfXJOhtV4oEDroL7ngix3ZUVWN9oIVVSDK02y1oQS1jCSEGUiUiauzb0g==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.712.0.tgz",
+      "integrity": "sha512-Hq1IIwOFutmHtTz3mROR1XhTDL8rxcYbYw3ajjgeMJB5tjcvodpfkfz/L4dxXZMwqylWf6SNQNAiaGh5mlsGGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.670.0",
-        "@aws-sdk/client-sts": "3.670.0",
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/credential-provider-node": "3.670.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.667.0",
-        "@aws-sdk/middleware-expect-continue": "3.667.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.669.0",
-        "@aws-sdk/middleware-host-header": "3.667.0",
-        "@aws-sdk/middleware-location-constraint": "3.667.0",
-        "@aws-sdk/middleware-logger": "3.667.0",
-        "@aws-sdk/middleware-recursion-detection": "3.667.0",
-        "@aws-sdk/middleware-sdk-s3": "3.669.0",
-        "@aws-sdk/middleware-ssec": "3.667.0",
-        "@aws-sdk/middleware-user-agent": "3.669.0",
-        "@aws-sdk/region-config-resolver": "3.667.0",
-        "@aws-sdk/signature-v4-multi-region": "3.669.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-endpoints": "3.667.0",
-        "@aws-sdk/util-user-agent-browser": "3.670.0",
-        "@aws-sdk/util-user-agent-node": "3.669.0",
-        "@aws-sdk/xml-builder": "3.662.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/eventstream-serde-browser": "^3.0.10",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
-        "@smithy/eventstream-serde-node": "^3.0.9",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-blob-browser": "^3.1.6",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/hash-stream-node": "^3.1.6",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/md5-js": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/client-sts": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.709.0",
+        "@aws-sdk/middleware-expect-continue": "3.709.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-location-constraint": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-sdk-s3": "3.709.0",
+        "@aws-sdk/middleware-ssec": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/signature-v4-multi-region": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@aws-sdk/xml-builder": "3.709.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/eventstream-serde-browser": "^3.0.14",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.11",
+        "@smithy/eventstream-serde-node": "^3.0.13",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-blob-browser": "^3.1.10",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/hash-stream-node": "^3.1.10",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/md5-js": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
-        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.1.6",
+        "@smithy/util-waiter": "^3.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -390,48 +391,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.670.0.tgz",
-      "integrity": "sha512-J+oz6uSsDvk4pimMDnKJb1wsV216zTrejvMTIL4RhUD1QPIVVOpteTdUShcjZUIZnkcJZGI+cym/SFK0kuzTpg==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.712.0.tgz",
+      "integrity": "sha512-tBo/eW3YpZ9f3Q1qA7aA8uliNFJJX0OP7R2IUJ8t6rqVTk15wWCEPNmXzUZKgruDnKUfCaF4+r9q/Yy4fBc9PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/middleware-host-header": "3.667.0",
-        "@aws-sdk/middleware-logger": "3.667.0",
-        "@aws-sdk/middleware-recursion-detection": "3.667.0",
-        "@aws-sdk/middleware-user-agent": "3.669.0",
-        "@aws-sdk/region-config-resolver": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-endpoints": "3.667.0",
-        "@aws-sdk/util-user-agent-browser": "3.670.0",
-        "@aws-sdk/util-user-agent-node": "3.669.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -440,49 +441,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.670.0.tgz",
-      "integrity": "sha512-4qDK2L36Q4J1lfemaHHd9ZxqKRaos3STp44qPAHf/8QyX6Uk5sXgZNVO2yWM7SIEtVKwwBh/fZAsdBkGPBfZcw==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.712.0.tgz",
+      "integrity": "sha512-xNFrG9syrG6pxUP7Ld/nu3afQ9+rbJM9qrE+wDNz4VnNZ3vLiJty4fH85zBFhOQ5OF2DIJTWsFzXGi2FYjsCMA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/credential-provider-node": "3.670.0",
-        "@aws-sdk/middleware-host-header": "3.667.0",
-        "@aws-sdk/middleware-logger": "3.667.0",
-        "@aws-sdk/middleware-recursion-detection": "3.667.0",
-        "@aws-sdk/middleware-user-agent": "3.669.0",
-        "@aws-sdk/region-config-resolver": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-endpoints": "3.667.0",
-        "@aws-sdk/util-user-agent-browser": "3.670.0",
-        "@aws-sdk/util-user-agent-node": "3.669.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -490,54 +491,54 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.670.0"
+        "@aws-sdk/client-sts": "^3.712.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.670.0.tgz",
-      "integrity": "sha512-bExrNo8ZVWorS3cjMZKQnA2HWqDmAzcZoSN/cPVoPFNkHwdl1lzPxvcLzmhpIr48JHgKfybBjrbluDZfIYeEog==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.712.0.tgz",
+      "integrity": "sha512-gIO6BD+hkEe3GKQhbiFP0zcNQv0EkP1Cl9SOstxS+X9CeudEgVX/xEPUjyoFVkfkntPBJ1g0I1u5xOzzRExl4g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.670.0",
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/credential-provider-node": "3.670.0",
-        "@aws-sdk/middleware-host-header": "3.667.0",
-        "@aws-sdk/middleware-logger": "3.667.0",
-        "@aws-sdk/middleware-recursion-detection": "3.667.0",
-        "@aws-sdk/middleware-user-agent": "3.669.0",
-        "@aws-sdk/region-config-resolver": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-endpoints": "3.667.0",
-        "@aws-sdk/util-user-agent-browser": "3.670.0",
-        "@aws-sdk/util-user-agent-node": "3.669.0",
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/core": "^2.4.8",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/hash-node": "^3.0.7",
-        "@smithy/invalid-dependency": "^3.0.7",
-        "@smithy/middleware-content-length": "^3.0.9",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.23",
-        "@smithy/util-defaults-mode-node": "^3.0.23",
-        "@smithy/util-endpoints": "^2.1.3",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -546,21 +547,21 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.667.0.tgz",
-      "integrity": "sha512-pMcDVI7Tmdsc8R3sDv0Omj/4iRParGY+uJtAfF669WnZfDfaBQaix2Mq7+Mu08vdjqO9K3gicFvjk9S1VLmOKA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
+      "integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/core": "^2.4.8",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/signature-v4": "^4.2.0",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -569,16 +570,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.667.0.tgz",
-      "integrity": "sha512-zZbrkkaPc54WXm+QAnpuv0LPNfsts0HPPd+oCECGs7IQRaFsGj187cwvPg9RMWDFZqpm64MdBDoA8OQHsqzYCw==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.709.0.tgz",
+      "integrity": "sha512-ZMAp9LSikvHDFVa84dKpQmow6wsg956Um20cKuioPpX2GGreJFur7oduD+tRJT6FtIOHn+64YH+0MwiXLhsaIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -586,21 +587,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.667.0.tgz",
-      "integrity": "sha512-sjtybFfERZWiqTY7fswBxKQLvUkiCucOWyqh3IaPo/4nE1PXRnaZCVG0+kRBPrYIxWqiVwytvZzMJy8sVZcG0A==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.709.0.tgz",
+      "integrity": "sha512-lIS7XLwCOyJnLD70f+VIRr8DNV1HPQe9oN6aguYrhoczqz7vDiVZLe3lh714cJqq9rdxzFypK5DqKHmcscMEPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-stream": "^3.1.9",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -608,50 +609,50 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.670.0.tgz",
-      "integrity": "sha512-TB1gacUj75leaTt2JsCTzygDSIk4ksv9uZoR7VenlgFPRktyOeT+fapwIVBeB2Qg7b9uxAY2K5XkKstDZyBEEw==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.712.0.tgz",
+      "integrity": "sha512-sTsdQ/Fm/suqMdpjhMuss/5uKL18vcuWnNTQVrG9iGNRqZLbq65MXquwbUpgzfoUmIcH+4CrY6H2ebpTIECIag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/credential-provider-env": "3.667.0",
-        "@aws-sdk/credential-provider-http": "3.667.0",
-        "@aws-sdk/credential-provider-process": "3.667.0",
-        "@aws-sdk/credential-provider-sso": "3.670.0",
-        "@aws-sdk/credential-provider-web-identity": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/credential-provider-imds": "^3.2.4",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.670.0"
+        "@aws-sdk/client-sts": "^3.712.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.670.0.tgz",
-      "integrity": "sha512-zwNrRYzubk4CaZ7zebeDhxsm8QtNWkbGKopZPOaZSnd5uqUGRcmx4ccVRngWUK68XDP44aEUWC8iU5Pc7btpHQ==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.712.0.tgz",
+      "integrity": "sha512-gXrHymW3rMRYORkPVQwL8Gi5Lu92F16SoZR543x03qCi7rm00oL9tRD85ACxkhprS1Wh8lUIUMNoeiwnYWTNuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.667.0",
-        "@aws-sdk/credential-provider-http": "3.667.0",
-        "@aws-sdk/credential-provider-ini": "3.670.0",
-        "@aws-sdk/credential-provider-process": "3.667.0",
-        "@aws-sdk/credential-provider-sso": "3.670.0",
-        "@aws-sdk/credential-provider-web-identity": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/credential-provider-imds": "^3.2.4",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-ini": "3.712.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -659,17 +660,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.667.0.tgz",
-      "integrity": "sha512-HZHnvop32fKgsNHkdhVaul7UzQ25sEc0j9yqA4bjhtbk0ECl42kj3f1pJ+ZU/YD9ut8lMJs/vVqiOdNThVdeBw==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.709.0.tgz",
+      "integrity": "sha512-IAC+jPlGQII6jhIylHOwh3RgSobqlgL59nw2qYTURr8hMCI0Z1p5y2ee646HTVt4WeCYyzUAXfxr6YI/Vitv+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -677,19 +678,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.670.0.tgz",
-      "integrity": "sha512-5PkA8BOy4q57Vhe9AESoHKZ7vjRbElNPKjXA4qC01xY+DitClRFz4O3B9sMzFp0PHlz9nDVSXXKgq0yzF/nAag==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.712.0.tgz",
+      "integrity": "sha512-8lCMxY7Lb9VK9qdlNXRJXE3W1UDVURnJZ3a4XWYNY6yr1TfQaN40mMyXX1oNlXXJtMV0szRvjM8dZj37E/ESAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.670.0",
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/token-providers": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/client-sso": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/token-providers": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -697,37 +698,37 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.667.0.tgz",
-      "integrity": "sha512-t8CFlZMD/1p/8Cli3rvRiTJpjr/8BO64gw166AHgFZYSN2h95L2l1tcW0jpsc3PprA32nLg1iQVKYt4WGM4ugw==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.709.0.tgz",
+      "integrity": "sha512-2lbDfE0IQ6gma/7BB2JpkjW5G0wGe4AS0x80oybYAYYviJmUtIR3Cn2pXun6bnAWElt4wYKl4su7oC36rs5rNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.667.0"
+        "@aws-sdk/client-sts": "^3.709.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.667.0.tgz",
-      "integrity": "sha512-XGz4jMAkDoTyFdtLz7ZF+C05IAhCTC1PllpvTBaj821z/L0ilhbqVhrT/f2Buw8Id/K5A390csGXgusXyrFFjA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.709.0.tgz",
+      "integrity": "sha512-03+tJOd7KIZOiqWH7Z8BOfQIWkKJgjcpKOJKZ6FR2KjWGUOE1G+bo11wF4UuHQ0RmpKnApt+pQghZmSnE7WEeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-arn-parser": "3.693.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-config-provider": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -736,15 +737,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.667.0.tgz",
-      "integrity": "sha512-0TiSL9S5DSG95NHGIz6qTMuV7GDKVn8tvvGSrSSZu/wXO3JaYSH0AElVpYfc4PtPRqVpEyNA7nnc7W56mMCLWQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.709.0.tgz",
+      "integrity": "sha512-Tbl/DFvE4rHl8lMb9IzetwK4tf5R3VeHZkvEXQalsWoK0tbEQ8kXWi7wAYO4qbE7bFVvaxKX+irjJjTxf3BrCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -752,21 +753,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.669.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.669.0.tgz",
-      "integrity": "sha512-01UQLoUzVwWMf+b+AEuwJ2lluBD+Cp8AcbyEHqvEaPdjGKHIS4BCvnY70mZYnAfRtL8R2h9tt7iI61oWU3Gjkg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.709.0.tgz",
+      "integrity": "sha512-wbYm9tkyCaqMeU82yjaXw7V5BxCSlSLNupENW63LC7Fvyo/aQzj6LjSMHcBpR2QwjBEhXCtF47L7aQ8SPTNhdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -775,15 +778,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
-      "integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.709.0.tgz",
+      "integrity": "sha512-8gQYCYAaIw4lOCd5WYdf15Y/61MgRsAnrb2eiTl+icMlUOOzl8aOl5iDwm/Idp0oHZTflwxM4XSvGXO83PRWcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -791,14 +794,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.667.0.tgz",
-      "integrity": "sha512-ob85H3HhT3/u5O+x0o557xGZ78vSNeSSwMaSitxdsfs2hOuoUl1uk+OeLpi1hkuJnL41FPpokV7TVII2XrFfmg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.709.0.tgz",
+      "integrity": "sha512-5YQWPXfZq7OE0jB2G0PP8K10GBod/YPJXb+1CfJS6FbQaglRoIm8KZmVEvJNnptSKyGtE62veeCcCQcfAUfFig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -806,14 +809,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
-      "integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.709.0.tgz",
+      "integrity": "sha512-jDoGSccXv9zebnpUoisjWd5u5ZPIalrmm6TjvPzZ8UqzQt3Beiz0tnQwmxQD6KRc7ADweWP5Ntiqzbw9xpVajg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -821,15 +824,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
-      "integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.709.0.tgz",
+      "integrity": "sha512-PObL/wLr4lkfbQ0yXUWaoCWu/jcwfwZzCjsUiXW/H6hW9b/00enZxmx7OhtJYaR6xmh/Lcx5wbhIoDCbzdv0tw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -837,19 +840,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.667.0.tgz",
-      "integrity": "sha512-dW3dd7HXaGi1fuZlcT4IOIi6fw29M6xKzP7yfcbh3DWi+EvN6TWyNFShuHUZOEjQOg7Qh3dyAa5jy/IbFw68fg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.709.0.tgz",
+      "integrity": "sha512-Q1Bi/S62HRayGBjgQ4vn3pru/zpb/Qz05yiVVxYeDUvXmJjUtoRbR18GzScnlhI8Y1do5BjG1uf5QtI0Q7yMLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-format-url": "3.667.0",
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/signature-v4": "^4.2.0",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-format-url": "3.709.0",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -857,24 +860,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.669.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.669.0.tgz",
-      "integrity": "sha512-b2QUQ7DcIcVCUFhvmFEDI90BemvQhO0ntIajllLqQSy88PSNdLDCVx5mIzfxaaK/1tdY/UsEDRRm1kMQHJDQpg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.709.0.tgz",
+      "integrity": "sha512-FwtOG9t9xsLoLOQZ6qAdsWOjx9dsO6t28IjIDV1l6Ixiu2oC0Yks7goONjJUH0IDE4pDDDGzmuq0sn1XtHhheA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/core": "^2.4.8",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/signature-v4": "^4.2.0",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-arn-parser": "3.693.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-stream": "^3.1.9",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -883,14 +886,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.667.0.tgz",
-      "integrity": "sha512-1wuAUZIkmZIvOmGg5qNQU821CGFHhkuKioxXgNh0DpUxZ9+AeiV7yorJr+bqkb2KBFv1i1TnzGRecvKf/KvZIQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.709.0.tgz",
+      "integrity": "sha512-2muiLe7YkmlwZp2SKz+goZrDThGfRq3o0FcJF3Puc0XGmcEPEDjih537mCoTrGgcXNFlBc7YChd84r3t72ySaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -898,18 +901,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.669.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.669.0.tgz",
-      "integrity": "sha512-K8ScPi45zjJrj5Y2gRqVsvKKQCQbvQBfYGcBw9ZOx9TTavH80bOCBjWg/GFnvs4f37tqVc1wMN2oGvcTF6HveQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.709.0.tgz",
+      "integrity": "sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.667.0",
-        "@aws-sdk/types": "3.667.0",
-        "@aws-sdk/util-endpoints": "3.667.0",
-        "@smithy/core": "^2.4.8",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -917,17 +920,17 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
-      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.709.0.tgz",
+      "integrity": "sha512-/NoCAMEVKAg3kBKOrNtgOfL+ECt6nrl+L7q2SyYmrcY4tVCmwuECVqewQaHc03fTnJijfKLccw0Fj+6wOCnB6w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -935,17 +938,17 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.669.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.669.0.tgz",
-      "integrity": "sha512-TVwlWAxfBHnFjnfTBQWUhzVJzjwVhkq1+KR0JZV7JrfqeyBOdZjAaV9ie3VNY9HUouecq1fDuKaSwe4JiWQsHg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.709.0.tgz",
+      "integrity": "sha512-m0vhJEy6SLbjL11K9cHzX/ZhCIj//1GkTbYk2d4tTQFSuPyJEkjmoeHk9dYm2mJy0wH48j29OJadI1JUsR5bOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.669.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/signature-v4": "^4.2.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/middleware-sdk-s3": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -953,33 +956,33 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
-      "integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.709.0.tgz",
+      "integrity": "sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.667.0"
+        "@aws-sdk/client-sso-oidc": "^3.709.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
-      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
+      "integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -987,9 +990,9 @@
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.568.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
-      "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.693.0.tgz",
+      "integrity": "sha512-WC8x6ca+NRrtpAH64rWu+ryDZI3HuLwlEr8EU6/dbC/pt+r/zC0PBoC15VEygUaBA+isppCikQpGyEDu0Yj7gQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1000,15 +1003,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
-      "integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.709.0.tgz",
+      "integrity": "sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-endpoints": "^2.1.3",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-endpoints": "^2.1.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1016,15 +1019,15 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.667.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.667.0.tgz",
-      "integrity": "sha512-S0D731SnEPnTfbJ/Dldw5dDrOc8uipK6NLXHDs2xIq0t61iwZLMEiN8yWCs2wAZVVJKpldUM1THLaaufU9SSSA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.709.0.tgz",
+      "integrity": "sha512-HGR11hx1KeFfoub/TACf+Yyal37lR85791Di2QPaElQThaqztLlppxale3EohKboOFf7Q/zvslJyM0fmgrlpQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1045,29 +1048,29 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.670.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.670.0.tgz",
-      "integrity": "sha512-iRynWWazqEcCKwGMcQcywKTDLdLvqts1Yx474U64I9OKQXXwhOwhXbF5CAPSRta86lkVNAVYJa/0Bsv45pNn1A==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.709.0.tgz",
+      "integrity": "sha512-/rL2GasJzdTWUURCQKFldw2wqBtY4k4kCiA2tVZSKg3y4Ey7zO34SW8ebaeCE2/xoWOyLR2/etdKyphoo4Zrtg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.669.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.669.0.tgz",
-      "integrity": "sha512-9jxCYrgggy2xd44ZASqI7AMiRVaSiFp+06Kg8BQSU0ijKpBJlwcsqIS8pDT/n6LxuOw2eV5ipvM2C0r1iKzrGA==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.712.0.tgz",
+      "integrity": "sha512-26X21bZ4FWsVpqs33uOXiB60TOWQdVlr7T7XONDFL/XN7GEpUJkWuuIB4PTok6VOmh1viYcdxZQqekXPuzXexQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.669.0",
-        "@aws-sdk/types": "3.667.0",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1083,13 +1086,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.662.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.662.0.tgz",
-      "integrity": "sha512-ikLkXn0igUpnJu2mCZjklvmcDGWT9OaLRv3JyC/cRkTaaSrblPjPM7KKsltxdMTLQ+v7fjCN0TsJpxphMfaOPA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.709.0.tgz",
+      "integrity": "sha512-2GPCwlNxeHspoK/Mc8nbk9cBOkSpp3j2SJUQmFnyQK6V/pR6II2oPRyZkMomug1Rc10hqlBHByMecq4zhV2uUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1575,9 +1578,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1603,13 +1606,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.4",
+        "@eslint/object-schema": "^2.1.5",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -1642,19 +1645,22 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
-      "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
+      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1700,9 +1706,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.12.0.tgz",
-      "integrity": "sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
+      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1710,9 +1716,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1720,9 +1726,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
+      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1733,9 +1739,9 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.0.tgz",
-      "integrity": "sha512-2cbWIHbZVEweE853g8jymffCA+NCMiuqeECeBBLm8dg2oFdjuGJhgN4UAbI+6v0CKbbhvtXA4qV8YR5Ji86nmw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1743,17 +1749,31 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.5.tgz",
-      "integrity": "sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.0",
+        "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.3.0"
       },
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -1771,9 +1791,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1915,9 +1935,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
-      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
       "cpu": [
         "arm"
       ],
@@ -1929,9 +1949,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
-      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
       "cpu": [
         "arm64"
       ],
@@ -1943,9 +1963,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
-      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
       "cpu": [
         "arm64"
       ],
@@ -1957,9 +1977,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
-      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
       "cpu": [
         "x64"
       ],
@@ -1970,10 +1990,38 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
-      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
       "cpu": [
         "arm"
       ],
@@ -1985,9 +2033,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
-      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
       "cpu": [
         "arm"
       ],
@@ -1999,9 +2047,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
-      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
       "cpu": [
         "arm64"
       ],
@@ -2013,9 +2061,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
-      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
       "cpu": [
         "arm64"
       ],
@@ -2026,10 +2074,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
-      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
       "cpu": [
         "ppc64"
       ],
@@ -2041,9 +2103,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
-      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
       "cpu": [
         "riscv64"
       ],
@@ -2055,9 +2117,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
-      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
       "cpu": [
         "s390x"
       ],
@@ -2069,9 +2131,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
       "cpu": [
         "x64"
       ],
@@ -2083,9 +2145,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
-      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
       "cpu": [
         "x64"
       ],
@@ -2097,9 +2159,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
-      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
       "cpu": [
         "arm64"
       ],
@@ -2111,9 +2173,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
-      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
       "cpu": [
         "ia32"
       ],
@@ -2125,9 +2187,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
-      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
       "cpu": [
         "x64"
       ],
@@ -2183,13 +2245,13 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.5.tgz",
-      "integrity": "sha512-DhNPnqTqPoG8aZ5dWkFOgsuY+i0GQ3CI6hMmvCoduNsnU9gUZWZBwGfDQsTTB7NvFPkom1df7jMIJWU90kuXXg==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2197,9 +2259,9 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
-      "integrity": "sha512-sbnURCwjF0gSToGlsBiAmd1lRCmSn72nu9axfJu5lIx6RUEgHu6GwTMbqCdhQSi0Pumcm5vFxsi9XWXb2mTaoA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2207,9 +2269,9 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
-      "integrity": "sha512-VDkpCYW+peSuM4zJip5WDfqvg2Mo/e8yxOv3VF1m11y7B8KKMKVFtmZWDe36Fvk8rGuWrPZHHXZ7rR7uM5yWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2218,16 +2280,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.9.tgz",
-      "integrity": "sha512-5d9oBf40qC7n2xUoHmntKLdqsyTMMo/r49+eqSIjJ73eDfEtljAxEhzIQ3bkgXJtR3xiv7YzMT/3FF3ORkjWdg==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2235,20 +2297,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.8.tgz",
-      "integrity": "sha512-x4qWk7p/a4dcf7Vxb2MODIf4OIcqNbK182WxRvZ/3oKPrf/6Fdic5sSElhO1UtXpWKBazWfqg0ZEK9xN1DsuHA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.5.tgz",
+      "integrity": "sha512-G8G/sDDhXA7o0bOvkc7bgai6POuSld/+XhNnWAbpQTpLv2OZPvyqQ58tLPPlz0bSNsXktldDDREIv1LczFeNEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -2257,16 +2317,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.4.tgz",
-      "integrity": "sha512-S9bb0EIokfYEuar4kEbLta+ivlKCWOCFsLZuilkNy9i0uEUEHSi47IFLPaxqqCl+0ftKmcOTHayY5nQhAuq7+w==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2274,27 +2334,27 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.6.tgz",
-      "integrity": "sha512-SBiOYPBH+5wOyPS7lfI150ePfGLhnp/eTu5RnV9xvhGvRiKfnl6HzRK9wehBph+il8FxS9KTeadx7Rcmf1GLPQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.10.tgz",
+      "integrity": "sha512-323B8YckSbUH0nMIpXn7HZsAVKHYHFUODa8gG9cHo0ySvA1fr5iWaNT+iIL0UCqUzG6QPHA3BSsBtRQou4mMqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.10.tgz",
-      "integrity": "sha512-1i9aMY6Pl/SmA6NjvidxnfBLHMPzhKu2BP148pEt5VwhMdmXn36PE2kWKGa9Hj8b0XGtCTRucpCncylevCtI7g==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.14.tgz",
+      "integrity": "sha512-kbrt0vjOIihW3V7Cqj1SXQvAI5BR8SnyQYsandva0AOR307cXAc+IhPngxIPslxTLfxwDpNu0HzCAq6g42kCPg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.9",
-        "@smithy/types": "^3.5.0",
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2302,13 +2362,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.7.tgz",
-      "integrity": "sha512-eVzhGQBPEqXXYHvIUku0jMTxd4gDvenRzUQPTmKVWdRvp9JUCKrbAXGQRYiGxUYq9+cqQckRm0wq3kTWnNtDhw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.11.tgz",
+      "integrity": "sha512-P2pnEp4n75O+QHjyO7cbw/vsw5l93K/8EWyjNCAAybYwUmj3M+hjSQZ9P5TVdUgEG08ueMAP5R4FkuSkElZ5tQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2316,14 +2376,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.9.tgz",
-      "integrity": "sha512-JE0Guqvt0xsmfQ5y1EI342/qtJqznBv8cJqkHZV10PwC8GWGU5KNgFbQnsVCcX+xF+qIqwwfRmeWoJCjuOLmng==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.13.tgz",
+      "integrity": "sha512-zqy/9iwbj8Wysmvi7Lq7XFLeDgjRpTbCfwBhJa8WbrylTAHiAu6oQTwdY7iu2lxigbc9YYr9vPv5SzYny5tCXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.9",
-        "@smithy/types": "^3.5.0",
+        "@smithy/eventstream-serde-universal": "^3.0.13",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2331,14 +2391,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.9.tgz",
-      "integrity": "sha512-bydfgSisfepCufw9kCEnWRxqxJFzX/o8ysXWv+W9F2FIyiaEwZ/D8bBKINbh4ONz3i05QJ1xE7A5OKYvgJsXaw==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.13.tgz",
+      "integrity": "sha512-L1Ib66+gg9uTnqp/18Gz4MDpJPKRE44geOjOQ2SVc0eiaO5l255ADziATZgjQjqumC7yPtp1XnjHlF1srcwjKw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.1.6",
-        "@smithy/types": "^3.5.0",
+        "@smithy/eventstream-codec": "^3.1.10",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2346,40 +2406,40 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
-      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.2.tgz",
+      "integrity": "sha512-R7rU7Ae3ItU4rC0c5mB2sP5mJNbCfoDc8I5XlYjIZnquyUwec7fEo78F6DA3SmgJgkU1qTMcZJuGblxZsl10ZA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.6.tgz",
-      "integrity": "sha512-BKNcMIaeZ9lB67sgo88iCF4YB35KT8X2dNJ8DqrtZNTgN6tUDYBKThzfGtos/mnZkGkW91AYHisESHmSiYQmKw==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.10.tgz",
+      "integrity": "sha512-elwslXOoNunmfS0fh55jHggyhccobFkexLYC1ZeZ1xP2BTSrcIBaHV2b4xUQOdctrSNOpMqOZH1r2XzWTEhyfA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^3.0.0",
-        "@smithy/chunked-blob-reader-native": "^3.0.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.7.tgz",
-      "integrity": "sha512-SAGHN+QkrwcHFjfWzs/czX94ZEjPJ0CrWJS3M43WswDXVEuP4AVy9gJ3+AF6JQHZD13bojmuf/Ap/ItDeZ+Qfw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2389,13 +2449,13 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.6.tgz",
-      "integrity": "sha512-sFSSt7cmCpFWZPfVx7k80Bgb1K2VJ27VmMxH8X+dDhp7Wv8IBgID4K2VK5ehMJROF8hQgcj4WywnkHIwX/xlwQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.10.tgz",
+      "integrity": "sha512-olomK/jZQ93OMayW1zfTHwcbwBdhcZOHsyWyiZ9h9IXvc1mCD/VuvzbLb3Gy/qNJwI4MANPLctTp2BucV2oU/Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -2404,13 +2464,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.7.tgz",
-      "integrity": "sha512-Bq00GsAhHeYSuZX8Kpu4sbI9agH2BNYnqUmmbTGWOhki9NVsWn2jFr896vvoTMH8KAjNX/ErC/8t5QHuEXG+IA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       }
     },
@@ -2428,26 +2488,26 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.7.tgz",
-      "integrity": "sha512-+wco9IN9uOW4tNGkZIqTR6IXyfO7Z8A+IOq82QCRn/f/xcmt7H1fXwmQVbfDSvbeFwfNnhv7s+u0G9PzPG6o2w==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.11.tgz",
+      "integrity": "sha512-3NM0L3i2Zm4bbgG6Ymi9NBcxXhryi3uE8fIfHJZIOfZVxOkGdjdgjR9A06SFIZCfnEIWKXZdm6Yq5/aPXFFhsQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.9.tgz",
-      "integrity": "sha512-t97PidoGElF9hTtLCrof32wfWMqC5g2SEJNxaVH3NjlatuNGsdxXRYO/t+RPnxA15RpYiS0f+zG7FuE2DeGgjA==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2455,18 +2515,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.4.tgz",
-      "integrity": "sha512-/ChcVHekAyzUbyPRI8CzPPLj6y8QRAfJngWcLMgsWxKVzw/RzBV69mSOzJYDD3pRwushA1+5tHtPF8fjmzBnrQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
+      "integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2474,19 +2535,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.23.tgz",
-      "integrity": "sha512-x9PbGXxkcXIpm6L26qRSCC+eaYcHwybRmqU8LO/WM2RRlW0g8lz6FIiKbKgGvHuoK3dLZRiQVSQJveiCzwnA5A==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.30.tgz",
+      "integrity": "sha512-6323RL2BvAR3VQpTjHpa52kH/iSHyxd/G9ohb2MkBk2Ucu+oMtRXT8yi7KTSIS9nb58aupG6nO0OlXnQOAcvmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/service-error-classification": "^3.0.7",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -2495,13 +2556,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.7.tgz",
-      "integrity": "sha512-VytaagsQqtH2OugzVTq4qvjkLNbWehHfGcGr0JLJmlDRrNCeZoWkWsSOw1nhS/4hyUUWF/TLGGml4X/OnEep5g==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2509,13 +2570,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.7.tgz",
-      "integrity": "sha512-EyTbMCdqS1DoeQsO4gI7z2Gzq1MoRFAeS8GkFYIwbedB7Lp5zlLHJdg+56tllIIG5Hnf9ZWX48YKSHlsKvugGA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2523,15 +2584,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.8.tgz",
-      "integrity": "sha512-E0rU0DglpeJn5ge64mk8wTGEXcQwmpUTY5Zr7IzTpDLmHKiIamINERNZYrPQjg58Ck236sEKSwRSHA4CwshU6Q==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2539,16 +2600,16 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.4.tgz",
-      "integrity": "sha512-49reY3+JgLMFNm7uTAKBWiKCA6XSvkNp9FqhVmusm2jpVnHORYFeFZ704LShtqWfjZW/nhX+7Iexyb6zQfXYIQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.2.tgz",
+      "integrity": "sha512-t4ng1DAd527vlxvOfKFYEe6/QFBcsj7WpNlWTyjorwXXcKw3XlltBGbyHfSJ24QT84nF+agDha9tNYpzmSRZPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.5",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2556,13 +2617,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.7.tgz",
-      "integrity": "sha512-QfzLi1GPMisY7bAM5hOUqBdGYnY5S2JAlr201pghksrQv139f8iiiMalXtjczIP5f6owxFn3MINLNUNvUkgtPw==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2570,13 +2631,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.4.tgz",
-      "integrity": "sha512-MlWK8eqj0JlpZBnWmjQLqmFp71Ug00P+m72/1xQB3YByXD4zZ+y9N4hYrR0EDmrUCZIkyATWHOXFgtavwGDTzQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2584,13 +2645,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.7.tgz",
-      "integrity": "sha512-65RXGZZ20rzqqxTsChdqSpbhA6tdt5IFNgG6o7e1lnPVLCe6TNWQq4rTl4N87hTDD8mV4IxJJnvyE7brbnRkQw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -2599,13 +2660,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.7.tgz",
-      "integrity": "sha512-Fouw4KJVWqqUVIu1gZW8BH2HakwLz6dvdrAhXeXfeymOBrZw+hcqaWs+cS1AZPVp4nlbeIujYrKA921ZW2WMPA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2613,26 +2674,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.7.tgz",
-      "integrity": "sha512-91PRkTfiBf9hxkIchhRKJfl1rsplRDyBnmyFca3y0Z3x/q0JJN480S83LBd8R6sBCkm2bBbqw2FHp0Mbh+ecSA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0"
+        "@smithy/types": "^3.7.2"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.8.tgz",
-      "integrity": "sha512-0NHdQiSkeGl0ICQKcJQ2lCOKH23Nb0EaAa7RDRId6ZqwXkw4LJyIyZ0t3iusD4bnKYDPLGy2/5e2rfUhrt0Acw==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2640,17 +2701,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
-      "integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+      "integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.11",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -2660,17 +2721,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.0.tgz",
-      "integrity": "sha512-nOfJ1nVQsxiP6srKt43r2My0Gp5PLWCW2ASqUioxIiGmu6d32v4Nekidiv5qOmmtzIrmaD+ADX5SKHUuhReeBQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
+      "integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-stream": "^3.1.9",
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2678,9 +2740,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.5.0.tgz",
-      "integrity": "sha512-QN0twHNfe8mNJdH9unwsCK13GURU7oEAZqkBI+rsvpv1jrmserO+WnLE7jidR9W/1dxwZ0u/CB01mV2Gms/K2Q==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2690,14 +2752,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.7.tgz",
-      "integrity": "sha512-70UbSSR8J97c1rHZOWhl+VKiZDqHWxs/iW8ZHrHp5fCCPLSBE7GcUlUvKSle3Ca+J9LLbYCj/A79BxztBvAfpA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       }
     },
@@ -2767,15 +2829,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.23.tgz",
-      "integrity": "sha512-Y07qslyRtXDP/C5aWKqxTPBl4YxplEELG3xRrz2dnAQ6Lq/FgNrcKWmV561nNaZmFH+EzeGOX3ZRMbU8p1T6Nw==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.30.tgz",
+      "integrity": "sha512-nLuGmgfcr0gzm64pqF2UT4SGWVG8UGviAdayDlVzJPNa6Z4lqvpDzdRXmLxtOdEjVlTOEdpZ9dd3ZMMu488mzg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -2784,18 +2846,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.23.tgz",
-      "integrity": "sha512-9Y4WH7f0vnDGuHUa4lGX9e2p+sMwODibsceSV6rfkZOvMC+BY3StB2LdO1NHafpsyHJLpwAgChxQ38tFyd6vkg==",
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.30.tgz",
+      "integrity": "sha512-OD63eWoH68vp75mYcfYyuVH+p7Li/mY4sYOROnauDrtObo1cS4uWfsy/zhOTW8F8ZPxQC1ZXZKVxoxvMGUv2Ow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/credential-provider-imds": "^3.2.4",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2803,14 +2865,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.3.tgz",
-      "integrity": "sha512-34eACeKov6jZdHqS5hxBMJ4KyWKztTMulhuQ2UdOoP6vVxMLrOKUqIXAwJe/wiWMhXhydLW664B02CNpQBQ4Aw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2831,13 +2893,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.7.tgz",
-      "integrity": "sha512-OVA6fv/3o7TMJTpTgOi1H5OTwnuUa8hzRzhSFDtZyNxi6OZ70L/FHattSmhE212I7b6WSOJAAmbYnvcjTHOJCA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2845,14 +2907,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.7.tgz",
-      "integrity": "sha512-nh1ZO1vTeo2YX1plFPSe/OXaHkLAHza5jpokNiiKX2M5YpNUv6RxGJZhpfmiR4jSvVHCjIDmILjrxKmP+/Ghug==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2860,15 +2922,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.9.tgz",
-      "integrity": "sha512-7YAR0Ub3MwTMjDfjnup4qa6W8gygZMxikBhFMPESi6ASsl/rZJhwLpF/0k9TuezScCojsM0FryGdz4LZtjKPPQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.2.tgz",
+      "integrity": "sha512-sInAqdiVeisUGYAv/FrXpmJ0b4WTFmciTRqzhb7wVuem9BHvhIG7tpiYHLDWrl2stOokNZpTTGqz3mzB2qFwXg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/types": "^3.5.0",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -2907,14 +2969,14 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.6.tgz",
-      "integrity": "sha512-xs/KAwWOeCklq8aMlnpk25LgxEYHKOEodfjfKclDMLcBJEVEKzDLxZxBQyztcuPJ7F54213NJS8PxoiHNMdItQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.2.0.tgz",
+      "integrity": "sha512-PpjSboaDUE6yl+1qlg3Si57++e84oXdWGbuFUSAciXsVfEZJJJupR2Nb0QuXHiunt2vGR+1PTizOMvnUPaG2Qg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.5",
-        "@smithy/types": "^3.5.0",
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2922,15 +2984,15 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.9.0.tgz",
-      "integrity": "sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.12.1.tgz",
+      "integrity": "sha512-fubZKIHSPuo07FgRTn6S4Nl0uXPRPYVNpyZzIDGfp7Fny6JjNus6kReLD7NI380JXi4HtUTSOZ34LBuNPO1XLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.8.0",
-        "eslint-visitor-keys": "^4.1.0",
-        "espree": "^10.2.0",
+        "@typescript-eslint/utils": "^8.13.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "estraverse": "^5.3.0",
         "picomatch": "^4.0.2"
       },
@@ -2977,13 +3039,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/sinon": {
@@ -3001,18 +3063,25 @@
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
-      "integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
+      "integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.9.0",
-        "@typescript-eslint/type-utils": "8.9.0",
-        "@typescript-eslint/utils": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0",
+        "@typescript-eslint/scope-manager": "8.18.0",
+        "@typescript-eslint/type-utils": "8.18.0",
+        "@typescript-eslint/utils": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3027,25 +3096,21 @@
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
-      "integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
+      "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MITClause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.9.0",
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/typescript-estree": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0",
+        "@typescript-eslint/scope-manager": "8.18.0",
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/typescript-estree": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3056,23 +3121,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
-      "integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
+      "integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0"
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3083,14 +3144,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
-      "integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
+      "integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.9.0",
-        "@typescript-eslint/utils": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.18.0",
+        "@typescript-eslint/utils": "8.18.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3101,16 +3162,15 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
-      "integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
+      "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3122,14 +3182,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
-      "integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
+      "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0",
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/visitor-keys": "8.18.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3144,23 +3204,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
+      "integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.9.0",
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/typescript-estree": "8.9.0"
+        "@typescript-eslint/scope-manager": "8.18.0",
+        "@typescript-eslint/types": "8.18.0",
+        "@typescript-eslint/typescript-estree": "8.18.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3170,18 +3228,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
-      "integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
+      "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.9.0",
-        "eslint-visitor-keys": "^3.4.3"
+        "@typescript-eslint/types": "8.18.0",
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3191,36 +3250,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.3.tgz",
-      "integrity": "sha512-2OJ3c7UPoFSmBZwqD2VEkUw6A/tzPF0LmW0ZZhhB8PFxuc+9IBG/FaSM+RLEenc7ljzFvGN+G0nGQoZnh7sy2A==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.8.tgz",
+      "integrity": "sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@bcoe/v8-coverage": "^0.2.3",
-        "debug": "^4.3.6",
+        "debug": "^4.3.7",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.11",
-        "magicast": "^0.3.4",
-        "std-env": "^3.7.0",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
         "test-exclude": "^7.0.1",
         "tinyrainbow": "^1.2.0"
       },
@@ -3228,8 +3274,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "2.1.3",
-        "vitest": "2.1.3"
+        "@vitest/browser": "2.1.8",
+        "vitest": "2.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3238,9 +3284,9 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.7.tgz",
-      "integrity": "sha512-pTWGW3y6lH2ukCuuffpan6kFxG6nIuoesbhMiQxskyQMRcCN5t9SXsKrNHvEw3p8wcCsgJoRqFZVkOTn6TjclA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.16.tgz",
+      "integrity": "sha512-xecwJYuAp11AFsd2aoSnTWO3Wckgu7rjBz1VOhvsDtZzI4s7z/WerAR4gxnEFy37scdsE8wSlP95/2ry6sLhSg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3259,14 +3305,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.3.tgz",
-      "integrity": "sha512-SNBoPubeCJhZ48agjXruCI57DvxcsivVDdWz+SSsmjTT4QN/DfHk3zB/xKsJqMs26bLZ/pNRLnCf0j679i0uWQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -3274,22 +3320,21 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.3.tgz",
-      "integrity": "sha512-eSpdY/eJDuOvuTA3ASzCjdithHa+GIF1L4PqtEELl6Qa3XafdMLBpBlZCIUCX2J+Q6sNmjmxtosAG62fK4BlqQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.3",
+        "@vitest/spy": "2.1.8",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.11"
+        "magic-string": "^0.30.12"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/spy": "2.1.3",
-        "msw": "^2.3.5",
+        "msw": "^2.4.9",
         "vite": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -3302,9 +3347,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.3.tgz",
-      "integrity": "sha512-XH1XdtoLZCpqV59KRbPrIhFCOO0hErxrQCMcvnQete3Vibb9UeIOX02uFPfVn3Z9ZXsq78etlfyhnkmIZSzIwQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^1.2.0"
@@ -3314,13 +3359,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.3.tgz",
-      "integrity": "sha512-JGzpWqmFJ4fq5ZKHtVO3Xuy1iF2rHGV4d/pdzgkYHm1+gOzNZtqjvyiaDGJytRyMU54qkxpNzCx+PErzJ1/JqQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.3",
+        "@vitest/utils": "2.1.8",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -3328,14 +3373,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.3.tgz",
-      "integrity": "sha512-qWC2mWc7VAXmjAkEKxrScWHWFyCQx/cmiZtuGqMi+WwqQJ2iURsVY4ZfAK6dVo6K2smKRU6l3BPwqEBvhnpQGg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.3",
-        "magic-string": "^0.30.11",
+        "@vitest/pretty-format": "2.1.8",
+        "magic-string": "^0.30.12",
         "pathe": "^1.1.2"
       },
       "funding": {
@@ -3343,25 +3388,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.3.tgz",
-      "integrity": "sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.0"
+        "tinyspy": "^3.0.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.3.tgz",
-      "integrity": "sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.3",
-        "loupe": "^3.1.1",
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
         "tinyrainbow": "^1.2.0"
       },
       "funding": {
@@ -3369,9 +3414,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
-      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3522,9 +3567,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
-      "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -3591,9 +3636,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3662,6 +3707,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -3715,32 +3767,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.12.0.tgz",
-      "integrity": "sha512-UVIOlTEWxwIopRL1wgSQYdnVDcEvs2wyaO6DGo5mXqe3r16IoCNWkR29iHhyaP4cICWjbgbmFUGAhh0GJRuGZw==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
+      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.6.0",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.12.0",
-        "@eslint/plugin-kit": "^0.2.0",
-        "@humanfs/node": "^0.16.5",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.9.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.17.0",
+        "@eslint/plugin-kit": "^0.2.3",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.1",
+        "@humanwhocodes/retry": "^0.4.1",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.1.0",
-        "eslint-visitor-keys": "^4.1.0",
-        "espree": "^10.2.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3754,8 +3806,7 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -3793,46 +3844,27 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-3.9.0.tgz",
-      "integrity": "sha512-qLsV6/94hokK+k77wUeLMEtB3tS/NtC9ke5OZCAaeCyK1VyVv7Ct0il16vkNNw/1IwNo8Fy60PKjQZSBcsVX5A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.3.0.tgz",
+      "integrity": "sha512-8tQ/wn1dFelul2WoXL/NQOEwvWO8H4Vjmsqpt3fDQrfgybr8kQ5Vgb9BQyVRB33ywQqjUApsiwi5Ci7grMPPRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.9.0",
-        "@typescript-eslint/utils": "^8.9.0",
-        "minimatch": "^9.0.5",
-        "natural-compare-lite": "^1.4.0"
+        "@typescript-eslint/types": "^8.18.0",
+        "@typescript-eslint/utils": "^8.18.0",
+        "natural-orderby": "^5.0.0"
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
-        "astro-eslint-parser": "^1.0.2",
-        "eslint": ">=8.0.0",
-        "svelte": ">=3.0.0",
-        "svelte-eslint-parser": "^0.41.1",
-        "vue-eslint-parser": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "astro-eslint-parser": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "svelte-eslint-parser": {
-          "optional": true
-        },
-        "vue-eslint-parser": {
-          "optional": true
-        }
+        "eslint": ">=8.0.0"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.1.0.tgz",
-      "integrity": "sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3847,9 +3879,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
-      "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3884,15 +3916,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
-      "integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.12.0",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.1.0"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3955,6 +3987,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4592,9 +4634,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -4617,12 +4659,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+    "node_modules/natural-orderby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
+      "integrity": "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nise": {
       "version": "6.1.1",
@@ -4779,9 +4824,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4799,9 +4844,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "dev": true,
       "funding": [
         {
@@ -4820,7 +4865,7 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -4890,9 +4935,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4906,22 +4951,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.24.0",
-        "@rollup/rollup-android-arm64": "4.24.0",
-        "@rollup/rollup-darwin-arm64": "4.24.0",
-        "@rollup/rollup-darwin-x64": "4.24.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
-        "@rollup/rollup-linux-arm64-musl": "4.24.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-musl": "4.24.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
-        "@rollup/rollup-win32-x64-msvc": "4.24.0",
+        "@rollup/rollup-android-arm-eabi": "4.28.1",
+        "@rollup/rollup-android-arm64": "4.28.1",
+        "@rollup/rollup-darwin-arm64": "4.28.1",
+        "@rollup/rollup-darwin-x64": "4.28.1",
+        "@rollup/rollup-freebsd-arm64": "4.28.1",
+        "@rollup/rollup-freebsd-x64": "4.28.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+        "@rollup/rollup-linux-arm64-musl": "4.28.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-musl": "4.28.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+        "@rollup/rollup-win32-x64-msvc": "4.28.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -5041,9 +5089,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5198,13 +5246,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5271,9 +5312,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5312,9 +5353,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5326,15 +5367,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.9.0.tgz",
-      "integrity": "sha512-AuD/FXGYRQyqyOBCpNLldMlsCGvmDNxptQ3Dp58/NXeB+FqyvTfXmMyba3PYa0Vi9ybnj7G8S/yd/4Cw8y47eA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.0.tgz",
+      "integrity": "sha512-Xq2rRjn6tzVpAyHr3+nmSg1/9k9aIHnJ2iZeOH7cfGOWqTkXTm3kwpQglEuLGdNrYvPF+2gtAs+/KF5rjVo+WQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.9.0",
-        "@typescript-eslint/parser": "8.9.0",
-        "@typescript-eslint/utils": "8.9.0"
+        "@typescript-eslint/eslint-plugin": "8.18.0",
+        "@typescript-eslint/parser": "8.18.0",
+        "@typescript-eslint/utils": "8.18.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5343,16 +5384,15 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.8.0"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5381,9 +5421,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.9.tgz",
-      "integrity": "sha512-20OVpJHh0PAM0oSOELa5GaZNWeDjcAvQjGXy2Uyr+Tp+/D2/Hdz6NLgpJLsarPTA2QJ6v8mX2P1ZfbsSKvdMkg==",
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5441,14 +5481,15 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.3.tgz",
-      "integrity": "sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.6",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
         "pathe": "^1.1.2",
         "vite": "^5.0.0"
       },
@@ -5463,30 +5504,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.3.tgz",
-      "integrity": "sha512-Zrxbg/WiIvUP2uEzelDNTXmEMJXuzJ1kCpbDvaKByFA9MNeO95V+7r/3ti0qzJzrxdyuUw5VduN7k+D3VmVOSA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
         "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
+        "std-env": "^3.8.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
         "tinyrainbow": "^1.2.0",
         "vite": "^5.0.0",
-        "vite-node": "2.1.3",
+        "vite-node": "2.1.8",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -5501,8 +5543,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@smithy/types": "^3.5.0",
         "@vitest/expect": "^2.1.3",
-        "aws-sdk-client-mock": "^4.1.0",
         "tslib": "^2.8.0"
       },
       "devDependencies": {
@@ -23,12 +22,16 @@
         "@types/node": "^22.10.2",
         "@vitest/coverage-v8": "^2.1.8",
         "@vitest/eslint-plugin": "^1.1.16",
+        "aws-sdk-client-mock": "^4.1.0",
         "eslint": "^9.17.0",
         "eslint-config-flat-gitignore": "^0.3.0",
         "eslint-plugin-perfectionist": "^4.3.0",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.0",
         "vitest": "^2.1.8"
+      },
+      "peerDependencies": {
+        "aws-sdk-client-mock": ">=2.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1035,9 +1038,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.568.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
-      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+      "version": "3.693.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.693.0.tgz",
+      "integrity": "sha512-ttrag6haJLWABhLqtg1Uf+4LgHWIMOVSYL+VYZmAp2v4PUGOwWmWQH0Zk8RM7YuQcLfH/EoR72/Yxz6A4FKcuw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1100,9 +1103,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1110,9 +1113,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1120,13 +1123,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
-      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.8"
+        "@babel/types": "^7.26.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1136,15 +1139,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
-      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1549,16 +1551,19 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -1588,9 +1593,9 @@
       }
     },
     "node_modules/@eslint/compat": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.0.tgz",
-      "integrity": "sha512-CkPWddN7J9JPrQedEr2X7AjK9y1jaMJtxZ4A/+jTMFA2+n5BWhcKHW/EbJyARqg2zzQfgtWUtVmG3hrG6+nGpg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.4.tgz",
+      "integrity": "sha512-S8ZdQj/N69YAtuqFt7653jwcvuUj131+6qGLUyDqfDg1OIoBQ66OCuXC473YQfO2AaxITTutiRQiDwoo7ZLYyg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1833,9 +1838,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2204,6 +2209,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -2213,6 +2219,7 @@
       "version": "11.2.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
       "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -2222,6 +2229,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
       "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -2233,6 +2241,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2242,6 +2251,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
@@ -3052,6 +3062,7 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
       "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
@@ -3061,6 +3072,7 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -3502,6 +3514,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
       "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/sinon": "^17.0.3",
@@ -3651,9 +3664,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3688,6 +3701,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4154,9 +4168,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4250,6 +4264,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4457,6 +4472,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -4503,6 +4519,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -4526,9 +4543,9 @@
       "license": "ISC"
     },
     "node_modules/magic-string": {
-      "version": "0.30.12",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
-      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "version": "0.30.15",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.15.tgz",
+      "integrity": "sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4673,6 +4690,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
       "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -4683,9 +4701,10 @@
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
-      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
@@ -4802,6 +4821,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -5057,6 +5077,7 @@
       "version": "18.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
       "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -5223,6 +5244,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5261,9 +5283,9 @@
       "license": "MIT"
     },
     "node_modules/tinypool": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.1.tgz",
-      "integrity": "sha512-URZYihUbRPcGv95En+sz6MfghfIc2OJ1sv/RmhWZLouPY0/8Vo80viwPvg3dlaS9fuq7fQMEfgRRK7BBZThBEA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5286,16 +5308,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -5347,6 +5359,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -40,19 +40,19 @@
     "tslib": "^2.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-ec2": "^3.670.0",
-    "@aws-sdk/client-s3": "^3.670.0",
-    "@eslint/js": "^9.12.0",
-    "@stylistic/eslint-plugin": "^2.9.0",
+    "@aws-sdk/client-ec2": "^3.712.0",
+    "@aws-sdk/client-s3": "^3.712.0",
+    "@eslint/js": "^9.17.0",
+    "@stylistic/eslint-plugin": "^2.12.1",
     "@types/eslint__js": "^8.42.3",
-    "@types/node": "^22.7.5",
-    "@vitest/coverage-v8": "^2.1.3",
-    "@vitest/eslint-plugin": "^1.1.7",
-    "eslint": "^9.12.0",
+    "@types/node": "^22.10.2",
+    "@vitest/coverage-v8": "^2.1.8",
+    "@vitest/eslint-plugin": "^1.1.16",
+    "eslint": "^9.17.0",
     "eslint-config-flat-gitignore": "^0.3.0",
-    "eslint-plugin-perfectionist": "^3.9.0",
-    "typescript": "^5.6.3",
-    "typescript-eslint": "^8.9.0",
-    "vitest": "^2.1.3"
+    "eslint-plugin-perfectionist": "^4.3.0",
+    "typescript": "^5.7.2",
+    "typescript-eslint": "^8.18.0",
+    "vitest": "^2.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "url": "https://github.com/stschulte/aws-sdk-client-mock-vitest/issues"
   },
   "homepage": "https://github.com/stschulte/aws-sdk-client-mock-vitest#readme",
+  "peerDependencies": {
+    "aws-sdk-client-mock": ">=2.2.0"
+  },
   "dependencies": {
     "@smithy/types": "^3.5.0",
     "@vitest/expect": "^2.1.3",
-    "aws-sdk-client-mock": "^4.1.0",
     "tslib": "^2.8.0"
   },
   "devDependencies": {
@@ -48,6 +50,7 @@
     "@types/node": "^22.10.2",
     "@vitest/coverage-v8": "^2.1.8",
     "@vitest/eslint-plugin": "^1.1.16",
+    "aws-sdk-client-mock": "^4.1.0",
     "eslint": "^9.17.0",
     "eslint-config-flat-gitignore": "^0.3.0",
     "eslint-plugin-perfectionist": "^4.3.0",

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -12,14 +12,14 @@ set -e
 DEPS=(
   "@vitest/expect"
   "tslib"
-
-  "aws-sdk-client-mock"
   "@smithy/types"
 )
 DDEPS=(
     "typescript"
     "@aws-sdk/client-ec2"
     "@aws-sdk/client-s3"
+
+    "aws-sdk-client-mock"
 
     "eslint"
     "@eslint/js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 export type { CustomMatcher } from './matcher.js';
 export {
+  toHaveReceivedAnyCommand,
   toHaveReceivedCommand,
   toHaveReceivedCommandOnce,
   toHaveReceivedCommandTimes,
   toHaveReceivedCommandWith,
   toHaveReceivedLastCommandWith,
   toHaveReceivedNthCommandWith,
+  toReceiveAnyCommand,
   toReceiveCommand,
   toReceiveCommandOnce,
   toReceiveCommandTimes,

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -9,25 +9,22 @@ import { ObjectContaining } from '@vitest/expect';
 
 import { notNull, ordinalOf } from './utils.js';
 
+/**
+ * We define some aliases
+ */
+interface AliasMatcher<R> {
+  toReceiveCommand: BaseMatcher<R>['toHaveReceivedCommand'];
+  toReceiveCommandOnce: BaseMatcher<R>['toHaveReceivedCommandOnce'];
+  toReceiveCommandTimes: BaseMatcher<R>['toHaveReceivedCommandTimes'];
+  toReceiveCommandWith: BaseMatcher<R>['toHaveReceivedCommandWith'];
+  toReceiveLastCommandWith: BaseMatcher<R>['toHaveReceivedLastCommandWith'];
+  toReceiveNthCommandWith: BaseMatcher<R>['toHaveReceivedNthCommandWith'];
+}
+
 type AwsCommandConstructur<
   Input extends object,
   Output extends MetadataBearer,
 > = new (input: Input) => AwsCommand<Input, Output>;
-
-/*
-  unfortunately RawMatcherFn from @vitest/expect defines a matcher like this
-
-      (this: T, received: any, expected: any, options?: any): ExpectationResult;
-
-  this does not work in our case since we may get multiple values for expected,
-  e.g.
-
-      toHaveReceivedNthCommandWith(PutObjectCommand, 2, {
-        Bucket: "foo",
-        Key: "test2.txt",
-      });
-*/
-type CustomMatcherFn = (this: MatcherState, ...args: any) => ExpectationResult;
 
 /**
  * This defines our matchers as they can be used in actual tests, see
@@ -80,19 +77,22 @@ interface BaseMatcher<R> {
   ): R;
 }
 
-/**
- * We define some aliases
- */
-interface AliasMatcher<R> {
-  toReceiveCommand: BaseMatcher<R>['toHaveReceivedCommand'];
-  toReceiveCommandOnce: BaseMatcher<R>['toHaveReceivedCommandOnce'];
-  toReceiveCommandTimes: BaseMatcher<R>['toHaveReceivedCommandTimes'];
-  toReceiveCommandWith: BaseMatcher<R>['toHaveReceivedCommandWith'];
-  toReceiveLastCommandWith: BaseMatcher<R>['toHaveReceivedLastCommandWith'];
-  toReceiveNthCommandWith: BaseMatcher<R>['toHaveReceivedNthCommandWith'];
-}
-
 type CustomMatcher<R = unknown> = AliasMatcher<R> & BaseMatcher<R>;
+
+/*
+  unfortunately RawMatcherFn from @vitest/expect defines a matcher like this
+
+      (this: T, received: any, expected: any, options?: any): ExpectationResult;
+
+  this does not work in our case since we may get multiple values for expected,
+  e.g.
+
+      toHaveReceivedNthCommandWith(PutObjectCommand, 2, {
+        Bucket: "foo",
+        Key: "test2.txt",
+      });
+*/
+type CustomMatcherFn = (this: MatcherState, ...args: any) => ExpectationResult;
 
 function formatCalls(
   context: MatcherState,
@@ -119,10 +119,10 @@ function formatCalls(
             expectedCall
               ? context.utils.diff(expectedCall, input, { omitAnnotationLines: true })
               : context.utils
-                .stringify(input)
-                .split('\n')
-                .map(line => `    ${line}`)
-                .join('\n'),
+                  .stringify(input)
+                  .split('\n')
+                  .map(line => `    ${line}`)
+                  .join('\n'),
             '',
           ].filter(notNull);
         }),

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -79,21 +79,6 @@ interface BaseMatcher<R> {
 
 type CustomMatcher<R = unknown> = AliasMatcher<R> & BaseMatcher<R>;
 
-/*
-  unfortunately RawMatcherFn from @vitest/expect defines a matcher like this
-
-      (this: T, received: any, expected: any, options?: any): ExpectationResult;
-
-  this does not work in our case since we may get multiple values for expected,
-  e.g.
-
-      toHaveReceivedNthCommandWith(PutObjectCommand, 2, {
-        Bucket: "foo",
-        Key: "test2.txt",
-      });
-*/
-type CustomMatcherFn = (this: MatcherState, ...args: any) => ExpectationResult;
-
 function formatCalls(
   context: MatcherState,
   client: AwsStub<any, any, any>,
@@ -130,11 +115,12 @@ function formatCalls(
       ].join('\n');
 }
 
-const toHaveReceivedCommandTimes: CustomMatcherFn = function (
+function toHaveReceivedCommandTimes(
+  this: MatcherState,
   client: AwsStub<any, any, any>,
   command: AwsCommandConstructur<any, any>,
   times: number,
-) {
+): ExpectationResult {
   const { isNot } = this;
   const callCount = client.commandCalls(command).length;
   const pass = callCount === times;
@@ -151,10 +137,11 @@ const toHaveReceivedCommandTimes: CustomMatcherFn = function (
 };
 const toReceiveCommandTimes = toHaveReceivedCommandTimes;
 
-const toHaveReceivedCommandOnce: CustomMatcherFn = function (
+function toHaveReceivedCommandOnce(
+  this: MatcherState,
   client: AwsStub<any, any, any>,
   command: AwsCommandConstructur<any, any>,
-) {
+): ExpectationResult {
   const { isNot } = this;
   const callCount = client.commandCalls(command).length;
   const pass = callCount === 1;
@@ -170,10 +157,11 @@ const toHaveReceivedCommandOnce: CustomMatcherFn = function (
 };
 const toReceiveCommandOnce = toHaveReceivedCommandOnce;
 
-const toHaveReceivedCommand: CustomMatcherFn = function (
+function toHaveReceivedCommand(
+  this: MatcherState,
   client: AwsStub<any, any, any>,
   command: AwsCommandConstructur<any, any>,
-) {
+): ExpectationResult {
   const { isNot } = this;
   const callCount = client.commandCalls(command).length;
   const pass = callCount >= 1;
@@ -189,11 +177,12 @@ const toHaveReceivedCommand: CustomMatcherFn = function (
 };
 const toReceiveCommand = toHaveReceivedCommand;
 
-const toHaveReceivedCommandWith: CustomMatcherFn = function (
+function toHaveReceivedCommandWith(
+  this: MatcherState,
   client: AwsStub<any, any, any>,
   command: AwsCommandConstructur<any, any>,
   input: Record<string, any>,
-) {
+): ExpectationResult {
   const { isNot, utils } = this;
   const calls = client.commandCalls(command);
 
@@ -215,12 +204,13 @@ const toReceiveCommandWith = toHaveReceivedCommandWith;
 /*
 
   */
-const toHaveReceivedNthCommandWith: CustomMatcherFn = function (
+function toHaveReceivedNthCommandWith(
+  this: MatcherState,
   client: AwsStub<any, any, any>,
   command: AwsCommandConstructur<any, any>,
   times: number,
   input: Record<string, any>,
-) {
+): ExpectationResult {
   const { isNot, utils } = this;
   const calls = client.commandCalls(command);
 
@@ -241,11 +231,12 @@ const toHaveReceivedNthCommandWith: CustomMatcherFn = function (
 };
 const toReceiveNthCommandWith = toHaveReceivedNthCommandWith;
 
-const toHaveReceivedLastCommandWith: CustomMatcherFn = function (
+function toHaveReceivedLastCommandWith(
+  this: MatcherState,
   client: AwsStub<any, any, any>,
   command: AwsCommandConstructur<any, any>,
   input: Record<string, any>,
-) {
+): ExpectationResult {
   const { isNot, utils } = this;
   const calls = client.commandCalls(command);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+export function notNull<T>(obj: null | T): obj is T {
+  return obj !== null;
+}
+
 export function ordinalOf(n: number): string {
   const j = n % 10;
   const k = n % 100;
@@ -6,8 +10,4 @@ export function ordinalOf(n: number): string {
   if (j === 2 && k !== 12) return `${s}nd`;
   if (j === 3 && k !== 13) return `${s}rd`;
   return `${s}th`;
-}
-
-export function notNull<T>(obj: null | T): obj is T {
-  return obj !== null;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  toHaveReceivedAnyCommand,
   toHaveReceivedCommand,
   toHaveReceivedCommandOnce,
   toHaveReceivedCommandTimes,
   toHaveReceivedCommandWith,
   toHaveReceivedLastCommandWith,
   toHaveReceivedNthCommandWith,
+  toReceiveAnyCommand,
   toReceiveCommand,
   toReceiveCommandOnce,
   toReceiveCommandTimes,
@@ -16,12 +18,14 @@ import {
 } from '../src/index.js';
 
 expect.extend({
+  toHaveReceivedAnyCommand,
   toHaveReceivedCommand,
   toHaveReceivedCommandOnce,
   toHaveReceivedCommandTimes,
   toHaveReceivedCommandWith,
   toHaveReceivedLastCommandWith,
   toHaveReceivedNthCommandWith,
+  toReceiveAnyCommand,
   toReceiveCommand,
   toReceiveCommandOnce,
   toReceiveCommandTimes,
@@ -38,12 +42,14 @@ describe('aws-sdk-client-mock-vitest', () => {
     'toHaveReceivedCommandWith',
     'toHaveReceivedLastCommandWith',
     'toHaveReceivedNthCommandWith',
+    'toHaveReceivedAnyCommand',
     'toReceiveCommand',
     'toReceiveCommandOnce',
     'toReceiveCommandTimes',
     'toReceiveCommandWith',
     'toReceiveLastCommandWith',
     'toReceiveNthCommandWith',
+    'toReceiveAnyCommand',
   ])('should be able to extend with %s', (matcher) => {
     expect(expect('something')).toHaveProperty(matcher);
   });

--- a/tests/matcher.test.ts
+++ b/tests/matcher.test.ts
@@ -9,12 +9,14 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vitest';
 
 import {
+  toHaveReceivedAnyCommand,
   toHaveReceivedCommand,
   toHaveReceivedCommandOnce,
   toHaveReceivedCommandTimes,
   toHaveReceivedCommandWith,
   toHaveReceivedLastCommandWith,
   toHaveReceivedNthCommandWith,
+  toReceiveAnyCommand,
   toReceiveCommand,
   toReceiveCommandOnce,
   toReceiveCommandTimes,
@@ -24,12 +26,14 @@ import {
 } from '../src/matcher.js';
 
 expect.extend({
+  toHaveReceivedAnyCommand,
   toHaveReceivedCommand,
   toHaveReceivedCommandOnce,
   toHaveReceivedCommandTimes,
   toHaveReceivedCommandWith,
   toHaveReceivedLastCommandWith,
   toHaveReceivedNthCommandWith,
+  toReceiveAnyCommand,
   toReceiveCommand,
   toReceiveCommandOnce,
   toReceiveCommandTimes,
@@ -1165,6 +1169,80 @@ describe('toHaveReceivedLastCommandWith', () => {
       expect(s3Mock).not.toHaveReceivedLastCommandWith(GetObjectCommand, {
         Key: 'file2.txt',
       });
+    });
+  });
+});
+
+describe('toReceiveAnyCommand', () => {
+  it.fails('fails when no command received', () => {
+    const s3Mock = mockClient(S3Client);
+    expect(s3Mock).toReceiveAnyCommand();
+  });
+
+  it('passes when one command was received', async () => {
+    const s3Mock = mockClient(S3Client);
+    const s3 = new S3Client({});
+    await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file1.txt' }));
+    expect(s3Mock).toReceiveAnyCommand();
+  });
+
+  describe('not', () => {
+    it('passes when no command received', () => {
+      const s3Mock = mockClient(S3Client);
+      expect(s3Mock).not.toReceiveAnyCommand();
+    });
+
+    it.fails('fails when one command was received', async () => {
+      const s3Mock = mockClient(S3Client);
+      const s3 = new S3Client({});
+      await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file1.txt' }));
+      expect(s3Mock).not.toReceiveAnyCommand();
+    });
+
+    it.fails('fails when multiple commands were received', async () => {
+      const s3Mock = mockClient(S3Client);
+      const s3 = new S3Client({});
+      await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file1.txt' }));
+      await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file2.txt' }));
+      await s3.send(new GetObjectAclCommand({ Bucket: 'foo', Key: 'file3.txt' }));
+      expect(s3Mock).not.toReceiveAnyCommand();
+    });
+  });
+});
+
+describe('toHaveReceivedAnyCommand', () => {
+  it.fails('fails when no command received', () => {
+    const s3Mock = mockClient(S3Client);
+    expect(s3Mock).toHaveReceivedAnyCommand();
+  });
+
+  it('passes when one command was received', async () => {
+    const s3Mock = mockClient(S3Client);
+    const s3 = new S3Client({});
+    await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file1.txt' }));
+    expect(s3Mock).toHaveReceivedAnyCommand();
+  });
+
+  describe('not', () => {
+    it('passes when no command received', () => {
+      const s3Mock = mockClient(S3Client);
+      expect(s3Mock).not.toHaveReceivedAnyCommand();
+    });
+
+    it.fails('fails when one command was received', async () => {
+      const s3Mock = mockClient(S3Client);
+      const s3 = new S3Client({});
+      await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file1.txt' }));
+      expect(s3Mock).not.toHaveReceivedAnyCommand();
+    });
+
+    it.fails('fails when multiple commands were received', async () => {
+      const s3Mock = mockClient(S3Client);
+      const s3 = new S3Client({});
+      await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file1.txt' }));
+      await s3.send(new GetObjectCommand({ Bucket: 'foo', Key: 'file2.txt' }));
+      await s3.send(new GetObjectAclCommand({ Bucket: 'foo', Key: 'file3.txt' }));
+      expect(s3Mock).not.toHaveReceivedAnyCommand();
     });
   });
 });


### PR DESCRIPTION
In some scenarios it may be helpful to know if any command was called on a specific AWS client.  This had been added for `aws-sdk-client-mock-jest` as of m-radzikowski/aws-sdk-client-mock#201

We now support the same interface.

Sample usage:
```ts
it('received a command', () => {
  const s3Mock = mockClient(S3Client);
  [..]
  expect(s3Mock).toHaveReceivedAnyCommand();
});
```

If any command was sent to the mock, this test passes. Otherwise it fails:
```text
Error: expected client "S3Client" to have been called, but was not called
```

You can also ensure no call had been made:

Sample usage:
```ts
it('did not receive a command', () => {
  const s3Mock = mockClient(S3Client);
  [..]
  expect(s3Mock).not.toHaveReceivedAnyCommand();
});
```

If no command was sent to the mock, this test passes. Otherwise it fails, listing all received commands and their inputs:
```text
Error: expected client "S3Client" to not receive any calls, but was called

Received:

   1st S3Client with GetObjectCommand call

    Object {
      "Bucket": "foo",
      "Key": "file1.txt",
    }

   2nd S3Client with GetObjectCommand call

    Object {
      "Bucket": "foo",
      "Key": "file2.txt",
    }

   3rd S3Client with GetObjectAclCommand call

    Object {
      "Bucket": "foo",
      "Key": "file3.txt",
    }

Number of calls: 3
```


Fixes #3