### PR TITLE
Add automated extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New import `aws-sdk-client-mock-vitest/extend` allows to easily extend
+  vitest expect
+
 ### Changed
 
 - Dropped unnecessary `tslib` dependency

--- a/README.md
+++ b/README.md
@@ -29,7 +29,33 @@ You must register the new matchers explicity (think about putting this to a
 register the matchers you are interested in, or register all available matchers
 (the easiest solution).
 
-To register all matchers use the following:
+## Automatic Setup (Recommended)
+
+The easiest way to get started is to use the automatic extend functionality which sets up both the matchers and TypeScript declarations in one import:
+
+```javascript
+/*
+  you may want to put the following into a file tests/setup.ts
+  and then specify your vite.config.ts as such
+
+      import { defineConfig } from "vitest/config";
+
+      export default defineConfig({
+        test: {
+          setupFiles: ["tests/setup.ts"],
+        },
+      });
+
+  to add the custom matchers before each test run
+*/
+import "aws-sdk-client-mock-vitest/extend";
+```
+
+This automatically extends vitest's `expect` with all available matchers and includes the necessary TypeScript declarations, so you don't need to create a separate `vitest.d.ts` file.
+
+## Manual Setup
+
+Alternatively, you can manually register matchers. To register all matchers use the following:
 
 ```javascript
 /*
@@ -49,7 +75,7 @@ To register all matchers use the following:
 import { expect } from "vitest";
 import { allCustomMatcher } from "aws-sdk-client-mock-vitest";
 
-expect.extend(allCustomMatcher)
+expect.extend(allCustomMatcher);
 ```
 
 You can also register just the matchers you care about:
@@ -111,7 +137,10 @@ expect.extend({
 
 ## Typescript support
 
-In case you are using typescript, create a `vitest.d.ts` file with the following content
+> [!NOTE]
+> If you're using the automatic setup with `import "aws-sdk-client-mock-vitest/extend"`, TypeScript declarations are automatically included and you can skip this section.
+
+In case you are using typescript with manual setup, create a `vitest.d.ts` file with the following content
 
 ```javascript
 // tests/vitest.d.ts

--- a/README.md
+++ b/README.md
@@ -24,77 +24,58 @@ on your AWS clients.
 npm install --save-dev aws-sdk-client-mock-vitest
 ```
 
-You must register the new matchers explicity (think about putting this to a
-[setup file](https://vitest.dev/config/#setupfiles)). You can either just
-register the matchers you are interested in, or register all available matchers
-(the easiest solution).
+In order to use the new matchers, we have to register them. The easiest way is
+to do this in a [setup file](https://vitest.dev/config/#setupfiles).
+
+You can either use a helper to extend with all matchers or manually only extend
+the matchers you are interested in.
 
 ## Automatic Setup (Recommended)
 
-The easiest way to get started is to use the automatic extend functionality which sets up both the matchers and TypeScript declarations in one import:
+Create a a new file `tests/setup.ts` with the following content (or adapt an
+existing one):
 
 ```javascript
-/*
-  you may want to put the following into a file tests/setup.ts
-  and then specify your vite.config.ts as such
+// tests/setup.ts
 
-      import { defineConfig } from "vitest/config";
-
-      export default defineConfig({
-        test: {
-          setupFiles: ["tests/setup.ts"],
-        },
-      });
-
-  to add the custom matchers before each test run
-*/
 import "aws-sdk-client-mock-vitest/extend";
 ```
 
-This automatically extends vitest's `expect` with all available matchers and includes the necessary TypeScript declarations, so you don't need to create a separate `vitest.d.ts` file.
+Now ensure this file is loaded by vitest before each test by adapting your
+`vite.config.ts` file:
+
+```javascript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Ensure our file is loaded and matchers are extended
+    setupFiles: ["tests/setup.ts"],
+  },
+});
+```
 
 ## Manual Setup
 
-Alternatively, you can manually register matchers. To register all matchers use the following:
+Alternatively, you can manually register matchers.
+
+Create a a new file `tests/setup.ts` with the following content (or adapt an
+existing one):
 
 ```javascript
-/*
-  you may want to put the following into a file tests/setup.ts
-  and then specify your vite.config.ts as such
+// tests/setup.ts
 
-      import { defineConfig } from "vitest/config";
-
-      export default defineConfig({
-        test: {
-          setupFiles: ["tests/setup.ts"],
-        },
-      });
-
-  to add the custom matchers before each test run
-*/
 import { expect } from "vitest";
 import { allCustomMatcher } from "aws-sdk-client-mock-vitest";
 
 expect.extend(allCustomMatcher);
 ```
 
-You can also register just the matchers you care about:
+We can only extend with individual matchers:
 
 ```javascript
-/*
-  you may want to put the following into a file tests/setup.ts
-  and then specify your vite.config.ts as such
+// tests/setup.ts
 
-      import { defineConfig } from "vitest/config";
-
-      export default defineConfig({
-        test: {
-          setupFiles: ["tests/setup.ts"],
-        },
-      });
-
-  to add the custom matchers before each test run
-*/
 import { expect } from "vitest";
 import {
   toReceiveCommandTimes,
@@ -132,6 +113,20 @@ expect.extend({
   toHaveReceivedAnyCommand,
   toReceiveCommandExactlyOnceWith,
   toHaveReceivedCommandExactlyOnceWith,
+});
+```
+
+Now ensure this file is loaded by vitest before each test by adapting your
+`vite.config.ts` file:
+
+```javascript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Ensure our file is loaded and matchers are extended
+    setupFiles: ["tests/setup.ts"],
+  },
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./extend": {
+      "types": "./dist/extend.d.ts",
+      "default": "./dist/extend.js"
     }
   },
   "scripts": {

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'vitest';
 
 import { allCustomMatcher, type CustomMatcher } from './matcher.js';
@@ -5,8 +7,6 @@ import { allCustomMatcher, type CustomMatcher } from './matcher.js';
 expect.extend(allCustomMatcher);
 
 declare module 'vitest' {
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any
-  interface Assertion<T = any> extends CustomMatcher<T> { }
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  interface AsymmetricMatchersContaining extends CustomMatcher { }
+  interface Assertion<T = any> extends CustomMatcher<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatcher {}
 }

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -1,0 +1,12 @@
+import { expect } from 'vitest';
+
+import { allCustomMatcher, type CustomMatcher } from './matcher.js';
+
+expect.extend(allCustomMatcher);
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any
+  interface Assertion<T = any> extends CustomMatcher<T> { }
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining extends CustomMatcher { }
+}

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -2,9 +2,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'vitest';
 
-import { allCustomMatcher, type CustomMatcher } from './matcher.js';
+import { allCustomMatcherWithAliases, type CustomMatcher } from './matcher.js';
 
-expect.extend(allCustomMatcher);
+expect.extend(allCustomMatcherWithAliases);
 
 declare module 'vitest' {
   interface Assertion<T = any> extends CustomMatcher<T> {}

--- a/src/extend.ts
+++ b/src/extend.ts
@@ -2,7 +2,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'vitest';
 
-import { allCustomMatcherWithAliases, type CustomMatcher } from './matcher.js';
+import type { CustomMatcher } from './matcher.js';
+
+import { allCustomMatcherWithAliases } from './matcher.js';
 
 expect.extend(allCustomMatcherWithAliases);
 

--- a/tests/extend.test.ts
+++ b/tests/extend.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from 'vitest';
 describe('extend', () => {
   const secretMock = mockClient(SecretsManagerClient);
 
-  it('should make matchers available', () => {
+  it('makes matchers available', () => {
     expect(secretMock).not.toHaveReceivedCommand(GetSecretValueCommand);
     expect(secretMock).toHaveReceivedCommandTimes(GetSecretValueCommand, 0);
     expect(secretMock).not.toHaveReceivedAnyCommand();

--- a/tests/extend.test.ts
+++ b/tests/extend.test.ts
@@ -1,0 +1,16 @@
+import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+
+import '../src/extend.js';
+
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, expect, it } from 'vitest';
+
+describe('extend', () => {
+  const secretMock = mockClient(SecretsManagerClient);
+
+  it('should make matchers available', () => {
+    expect(secretMock).not.toHaveReceivedCommand(GetSecretValueCommand);
+    expect(secretMock).toHaveReceivedCommandTimes(GetSecretValueCommand, 0);
+    expect(secretMock).not.toHaveReceivedAnyCommand();
+  });
+});


### PR DESCRIPTION
Hey there! Thanks for the library. I've just started migrating to vitest and noticed I was creating the following file everywhere. Could we instead export it via your library via a subpath import as a quick and easy way to extend expect?

I decided to use a subpath import so the types don't get augmented when importing the base import