### PR TITLE
Deploy to npm registry with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,13 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   release:
     name: Release Module
     runs-on: "ubuntu-latest"
+    environment: production
 
     steps:
       - name: Checkout
@@ -35,6 +37,9 @@ jobs:
           node-version: "22"
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -43,5 +48,3 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,9 @@ jobs:
           node-version: ${{ matrix.node_version }}
           cache: 'npm'
 
+      - name: Check node version
+        run: npm --version
+
       - name: Install Dependencies
         run: npm ci
 


### PR DESCRIPTION
Instead of maintaining a node auth token we now make use of OIDC.