### PR TITLE
chore: export BaseMatcher and AliasMatcher types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { CustomMatcher } from './matcher.js';
+export type { AliasMatcher, BaseMatcher, CustomMatcher } from './matcher.js';
 export {
   allCustomMatcher,
   allCustomMatcherWithAliases,

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -342,7 +342,7 @@ const allCustomMatcherWithAliases = {
   toReceiveNthCommandWith,
 };
 
-export type { CustomMatcher };
+export type { AliasMatcher, BaseMatcher, CustomMatcher };
 export {
   allCustomMatcher,
   allCustomMatcherWithAliases,


### PR DESCRIPTION
## Summary
Closes #23

Export the `BaseMatcher` and `AliasMatcher` interfaces from the package entry point.

## Motivation

Consumers who want stricter type augmentation (e.g. excluding alias matchers from `expect.extend` typings) currently have no way to reference `BaseMatcher` directly. This forces workarounds like manually re-declaring the interface or using `CustomMatcher` and manually omitting keys.

With `BaseMatcher` exported, consumers can write:

```typescript
import type { BaseMatcher } from 'aws-sdk-client-mock-vitest';

type StrictMatcher<T = unknown> = Pick<BaseMatcher<T>,
  | 'toHaveReceivedAnyCommand'
  | 'toHaveReceivedCommand'
  | 'toHaveReceivedCommandExactlyOnceWith'
  | 'toHaveReceivedCommandOnce'
  | 'toHaveReceivedCommandTimes'
  | 'toHaveReceivedCommandWith'
  | 'toHaveReceivedLastCommandWith'
  | 'toHaveReceivedNthCommandWith'
>;
```

## Changes

- `src/matcher.ts`: Add `AliasMatcher` and `BaseMatcher` to the `export type` statement
- `src/index.ts`: Re-export `AliasMatcher` and `BaseMatcher` types

## Notes

- No runtime changes — types only
- All existing tests pass (215 passed)
- Build passes cleanly

