### PR TITLE
Update test matrix to include Node 26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: "actions/checkout@v5"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: "${{ github.ref }}"
           clean: true
@@ -32,13 +32,13 @@ jobs:
           echo "version=${metadata_version}" >> $GITHUB_OUTPUT
 
       - name: Setup Node 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "24"
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup Node 20
-        uses: actions/setup-node@v6
+      - name: Setup Node 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
-          cache: 'npm'
+          node-version: 24
+          cache: npm
 
       - name: Install Dependencies
         run: npm ci
@@ -34,13 +34,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup Node 20
-        uses: actions/setup-node@v6
+      - name: Setup Node 24
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
-          cache: 'npm'
+          node-version: 24
+          cache: npm
 
       - name: Install Dependencies
         run: npm ci
@@ -54,15 +54,15 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 20
           - 22
           - 24
+          - 26
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node ${{ matrix.node_version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'npm'
@@ -77,7 +77,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.node_version == 24
         with:
           use_oidc: true


### PR DESCRIPTION
Our node test matrix previously tested on Node.js versions `20`, `22` and `24`. Since we do not officially support Node.js `20` anymore (vitest dropped support for it), we now update our test matrix for `22` (oldest supported version), `24` (current LTS) and `26` (current).

We also update all GitHub actions and pin our actions to immutable tags to improve security against supply chain attacks.